### PR TITLE
[2024.07.12] feat/#3 login >> 로그인 기능 구현

### DIFF
--- a/src/main/java/jira6/fate/domain/user/entity/User.java
+++ b/src/main/java/jira6/fate/domain/user/entity/User.java
@@ -45,4 +45,8 @@ public class User extends Timestamped {
         this.userRole = UserRole.MANAGER;
     }
 
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/src/main/java/jira6/fate/global/exception/ErrorCode.java
+++ b/src/main/java/jira6/fate/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 	INVALID_REQUEST(400, "입력값을 확인해주세요."),
 	INCORRECT_PASSWORD(400, "입력하신 비밀번호가 일치하지 않습니다."),
 	INCORRECT_MANAGER_KEY(400, "입력하신 MANAGER키가 일치하지 않습니다."),
+	CHECK_USERNAME_PASSWORD(400, "아이디, 비밀번호를 확인해주세요."),
 	USER_NOT_FOUND(400, "해당하는 유저를 찾을 수 없습니다."),
 	USER_NOT_UNIQUE(409,"사용 중인 아이디입니다."),
 	USER_NOT_TEAM(404, "해당 유저가 팀에 없습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #3 
> Close #3 

## 📑 작업 내용
> - username과 password가 일치하는 경우 로그인 성공
> - 로그인 성공 시 Header에 AccessToken, Cookie에 RefreshToken 담아서 넘겨주기
> - 로그인 성공 시 DB refresh_token에 RefreshToken 저장
> - 예외 처리
>   - 유효하지 않은 사용자 정보로 로그인을 시도한 경우(회원가입을 하지 않거나, 회원 탈퇴한 경우)
>   - username과 password가 일치하지 않는 사용자 정보로 로그인을 시도한 경우

## 💭 리뷰 요구사항(선택)
>
